### PR TITLE
Allow null gitlab_project_prefix

### DIFF
--- a/src/schemas/project_type.yaml
+++ b/src/schemas/project_type.yaml
@@ -67,6 +67,7 @@ write:
     gitlab_project_prefix:
       description: Prefix for this project type in GitLab
       type: string
+      nullable: true
   required:
     - name
     - plural_name


### PR DESCRIPTION
This commit updates the openapi spec to allow null values for gitlab_project_prefix, which matches our Postgres schema. This also helps maintain the philosophy that Imbi should be capable of integrating with other tools and platforms