### PR TITLE
Fix recursive type

### DIFF
--- a/src/components/requests.yaml
+++ b/src/components/requests.yaml
@@ -1,0 +1,15 @@
+jsonPatch:
+  description: JSON Patch Payload
+  content:
+    application/json:
+      schema:
+        $ref: './schemas.yaml#/jsonPatch'
+    application/msgpack:
+      schema:
+        $ref: './schemas.yaml#/jsonPatch'
+    application/json-patch+json:
+      schema:
+        $ref: './schemas.yaml#/jsonPatch'
+    application/json-patch+msgpack:
+      schema:
+        $ref: './schemas.yaml#/jsonPatch'

--- a/src/components/schemas.yaml
+++ b/src/components/schemas.yaml
@@ -1,4 +1,16 @@
 ---
+recursiveType:
+  description: The value to add, replace, or test
+  oneOf:
+    - type: array
+      items:
+        $ref: '#/recursiveType'
+    - type: boolean
+    - type: number
+    - type: object
+    - type: string
+  nullable: true
+
 jsonPatch:
   title: JSON Patch
   description: A JSONPatch document as defined by RFC 6902
@@ -17,14 +29,7 @@ jsonPatch:
             type: string
             enum: [add, replace, test]
           value:
-            description: The value to add, replace or test
-            oneOf:
-              - type: array
-              - type: boolean
-              - type: number
-              - type: object
-              - type: string
-            nullable: true
+            $ref: '#/recursiveType'
         required:
           - path
           - op

--- a/src/endpoints/cookie_cutter.yaml
+++ b/src/endpoints/cookie_cutter.yaml
@@ -74,17 +74,7 @@ paths:
         operations to apply.
       tags: [Cookie Cutters]
       requestBody:
-        description: JSON Patch Payload
-        content:
-          application/json: &patchContent
-            schema:
-              $ref: '../components/schemas.yaml#/jsonPatch'
-          application/msgpack:
-            <<: *patchContent
-          application/json-patch+json:
-            <<: *patchContent
-          application/json-patch+msgpack:
-            <<: *patchContent
+        $ref: '../components/requests.yaml#/jsonPatch'
       responses:
         '200': { $ref: '#/components/responses/Success' }
         '304': { $ref: '../components/responses.yaml#/NoChanges' }

--- a/src/endpoints/environment.yaml
+++ b/src/endpoints/environment.yaml
@@ -69,17 +69,7 @@ paths:
         operations to apply.
       tags: [Environments]
       requestBody:
-        description: JSON Patch Payload
-        content:
-          application/json: &patchContent
-            schema:
-              $ref: '../components/schemas.yaml#/jsonPatch'
-          application/msgpack:
-            <<: *patchContent
-          application/json-patch+json:
-            <<: *patchContent
-          application/json-patch+msgpack:
-            <<: *patchContent
+        $ref: '../components/requests.yaml#/jsonPatch'
       responses:
         '200': { $ref: '#/components/responses/Success' }
         '304': { $ref: '../components/responses.yaml#/NoChanges' }

--- a/src/endpoints/group.yaml
+++ b/src/endpoints/group.yaml
@@ -67,17 +67,7 @@ paths:
         operations to apply.
       tags: [Groups]
       requestBody:
-        description: JSON Patch Payload
-        content:
-          application/json: &patchContent
-            schema:
-              $ref: '../components/schemas.yaml#/jsonPatch'
-          application/msgpack:
-            <<: *patchContent
-          application/json-patch+json:
-            <<: *patchContent
-          application/json-patch+msgpack:
-            <<: *patchContent
+        $ref: '../components/requests.yaml#/jsonPatch'
       responses:
         '200': { $ref: '#/components/responses/Success' }
         '304': { $ref: '../components/responses.yaml#/NoChanges' }

--- a/src/endpoints/namespace.yaml
+++ b/src/endpoints/namespace.yaml
@@ -74,17 +74,7 @@ paths:
         operations to apply.
       tags: [Namespaces]
       requestBody:
-        description: JSON Patch Payload
-        content:
-          application/json: &patchContent
-            schema:
-              $ref: '../components/schemas.yaml#/jsonPatch'
-          application/msgpack:
-            <<: *patchContent
-          application/json-patch+json:
-            <<: *patchContent
-          application/json-patch+msgpack:
-            <<: *patchContent
+        $ref: '../components/requests.yaml#/jsonPatch'
       responses:
         '200': { $ref: '#/components/responses/Success' }
         '304': { $ref: '../components/responses.yaml#/NoChanges' }

--- a/src/endpoints/operations_log.yaml
+++ b/src/endpoints/operations_log.yaml
@@ -168,17 +168,7 @@ paths:
         operations to apply.
       tags: [Operations Log]
       requestBody:
-        description: JSON Patch Payload
-        content:
-          application/json: &patchContent
-            schema:
-              $ref: '../components/schemas.yaml#/jsonPatch'
-          application/msgpack:
-            <<: *patchContent
-          application/json-patch+json:
-            <<: *patchContent
-          application/json-patch+msgpack:
-            <<: *patchContent
+        $ref: '../components/requests.yaml#/jsonPatch'
       responses:
         '200': { $ref: '#/components/responses/Success' }
         '304': { $ref: '../components/responses.yaml#/NoChanges' }

--- a/src/endpoints/project_fact_type.yaml
+++ b/src/endpoints/project_fact_type.yaml
@@ -106,17 +106,7 @@ paths:
         operations to apply.
       tags: [Fact Types]
       requestBody:
-        description: JSON Patch Payload
-        content:
-          application/json: &patchContent
-            schema:
-              $ref: '../components/schemas.yaml#/jsonPatch'
-          application/msgpack:
-            <<: *patchContent
-          application/json-patch+json:
-            <<: *patchContent
-          application/json-patch+msgpack:
-            <<: *patchContent
+        $ref: '../components/requests.yaml#/jsonPatch'
       responses:
         '200': { $ref: '#/components/responses/Success' }
         '304': { $ref: '../components/responses.yaml#/NoChanges' }

--- a/src/endpoints/project_fact_type_enum.yaml
+++ b/src/endpoints/project_fact_type_enum.yaml
@@ -84,17 +84,7 @@ paths:
         operations to apply.
       tags: [Fact Type Enums]
       requestBody:
-        description: JSON Patch Payload
-        content:
-          application/json: &patchContent
-            schema:
-              $ref: '../components/schemas.yaml#/jsonPatch'
-          application/msgpack:
-            <<: *patchContent
-          application/json-patch+json:
-            <<: *patchContent
-          application/json-patch+msgpack:
-            <<: *patchContent
+        $ref: '../components/requests.yaml#/jsonPatch'
       responses:
         '200': { $ref: '#/components/responses/Success' }
         '304': { $ref: '../components/responses.yaml#/NoChanges' }

--- a/src/endpoints/project_fact_type_range.yaml
+++ b/src/endpoints/project_fact_type_range.yaml
@@ -79,17 +79,7 @@ paths:
         operations to apply.
       tags: [Fact Type Ranges]
       requestBody:
-        description: JSON Patch Payload
-        content:
-          application/json: &patchContent
-            schema:
-              $ref: '../components/schemas.yaml#/jsonPatch'
-          application/msgpack:
-            <<: *patchContent
-          application/json-patch+json:
-            <<: *patchContent
-          application/json-patch+msgpack:
-            <<: *patchContent
+        $ref: '../components/requests.yaml#/jsonPatch'
       responses:
         '200': { $ref: '#/components/responses/Success' }
         '304': { $ref: '../components/responses.yaml#/NoChanges' }

--- a/src/endpoints/project_link_type.yaml
+++ b/src/endpoints/project_link_type.yaml
@@ -65,17 +65,7 @@ paths:
         operations to apply.
       tags: [Project Link Types]
       requestBody:
-        description: JSON Patch Payload
-        content:
-          application/json: &patchContent
-            schema:
-              $ref: '../components/schemas.yaml#/jsonPatch'
-          application/msgpack:
-            <<: *patchContent
-          application/json-patch+json:
-            <<: *patchContent
-          application/json-patch+msgpack:
-            <<: *patchContent
+        $ref: '../components/requests.yaml#/jsonPatch'
       responses:
         '200': { $ref: '#/components/responses/Success' }
         '304': { $ref: '../components/responses.yaml#/NoChanges' }

--- a/src/endpoints/project_links.yaml
+++ b/src/endpoints/project_links.yaml
@@ -79,17 +79,7 @@ paths:
         operations to apply.
       tags: [Project Links]
       requestBody:
-        description: JSON Patch Payload
-        content:
-          application/json: &patchContent
-            schema:
-              $ref: '../components/schemas.yaml#/jsonPatch'
-          application/msgpack:
-            <<: *patchContent
-          application/json-patch+json:
-            <<: *patchContent
-          application/json-patch+msgpack:
-            <<: *patchContent
+        $ref: '../components/requests.yaml#/jsonPatch'
       responses:
         '200': { $ref: '#/components/responses/Success' }
         '304': { $ref: '../components/responses.yaml#/NoChanges' }

--- a/src/endpoints/project_type.yaml
+++ b/src/endpoints/project_type.yaml
@@ -69,17 +69,7 @@ paths:
         operations to apply.
       tags: [Project Types]
       requestBody:
-        description: JSON Patch Payload
-        content:
-          application/json: &patchContent
-            schema:
-              $ref: '../components/schemas.yaml#/jsonPatch'
-          application/msgpack:
-            <<: *patchContent
-          application/json-patch+json:
-            <<: *patchContent
-          application/json-patch+msgpack:
-            <<: *patchContent
+        $ref: '../components/requests.yaml#/jsonPatch'
       responses:
         '200': { $ref: '#/components/responses/Success' }
         '304': { $ref: '../components/responses.yaml#/NoChanges' }

--- a/src/endpoints/project_urls.yaml
+++ b/src/endpoints/project_urls.yaml
@@ -80,17 +80,7 @@ paths:
         operations to apply.
       tags: [Project URLs]
       requestBody:
-        description: JSON Patch Payload
-        content:
-          application/json: &patchContent
-            schema:
-              $ref: '../components/schemas.yaml#/jsonPatch'
-          application/msgpack:
-            <<: *patchContent
-          application/json-patch+json:
-            <<: *patchContent
-          application/json-patch+msgpack:
-            <<: *patchContent
+        $ref: '../components/requests.yaml#/jsonPatch'
       responses:
         '200': { $ref: '#/components/responses/Success' }
         '304': { $ref: '../components/responses.yaml#/NoChanges' }

--- a/src/endpoints/projects.yaml
+++ b/src/endpoints/projects.yaml
@@ -133,17 +133,7 @@ paths:
         operations to apply.
       tags: [Projects]
       requestBody:
-        description: JSON Patch Payload
-        content:
-          application/json: &patchContent
-            schema:
-              $ref: '../components/schemas.yaml#/jsonPatch'
-          application/msgpack:
-            <<: *patchContent
-          application/json-patch+json:
-            <<: *patchContent
-          application/json-patch+msgpack:
-            <<: *patchContent
+        $ref: '../components/requests.yaml#/jsonPatch'
       responses:
         '200': { $ref: '#/components/responses/Success' }
         '304': { $ref: '../components/responses.yaml#/NoChanges' }


### PR DESCRIPTION
The schema for a JSON patch request was not valid according to the OpenAPI spec.  Specifically, an `array` is required to have an `items` clause.  You can make this work with a recursive `$ref`.  I also moved the JSON Patch request into a reusable component (in _components/requests.yaml_) since we were repeating it in a lot of places.