### PR TITLE
Add /projects/{id}/notes/...

### DIFF
--- a/src/components/headers.yaml
+++ b/src/components/headers.yaml
@@ -13,8 +13,14 @@ Last-Modified:
 Link:
   description: |
     Links to related resources, in the format defined by
-    [RFC 5988](https://tools.ietf.org/html/rfc5988#section-5).
-    This will include a link with relation type `canonical` with the
-    canonical link to the item.
+    [RFC 5988](https://tools.ietf.org/html/rfc5988#section-5).  The following
+    link relation types are used in this API.
+    
+    | "rel" value | Description                                      |
+    |:-----------:| -----------                                      |
+    | canonical   | the canonical URL for the resource if one exists |
+    | first       | link to the first page in a collection           |
+    | next        | link to the next page in the collection          |
+
   schema:
     type: string

--- a/src/endpoints/project_notes.yaml
+++ b/src/endpoints/project_notes.yaml
@@ -1,0 +1,110 @@
+components:
+  ProjectId:
+    name: id
+    in: path
+    required: true
+    description: Project ID
+    schema:
+      type: number
+  ProjectNote:
+    description: Success
+    content:
+      application/json:
+        schema:
+          $ref: '../schemas/project_note.yaml#/read'
+      application/msgpack:
+        schema:
+          $ref: '../schemas/project_note.yaml#/read'
+
+paths:
+  collection:
+    parameters:
+      - $ref: '#/components/ProjectId'
+    get:
+      summary: Get Collection
+      description: "Retrieve the notes for a project"
+      tags: [Project Notes]
+      parameters:
+        - name: limit
+          description: Maximum number of items to return
+          in: query
+          schema:
+            type: number
+            minimum: 1
+            default: 100
+          required: false
+        - name: page_token
+          description: opaque pagination token
+          in: query
+          schema:
+            type: string
+          required: false
+      responses:
+        '200':
+          description: Success
+          content:
+            application/json:
+              schema:
+                type: array
+                items:
+                  $ref: '../schemas/project_note.yaml#/read'
+          headers:
+            Link:
+              $ref: '../components/headers.yaml#/Link'
+    post:
+      summary: Create Record
+      description: "Create a new note for a project"
+      tags: [Project Notes]
+      requestBody:
+        description: Note content
+        content:
+          application/json:
+            schema:
+              $ref: '../schemas/project_note.yaml#/write'
+          application/msgpack:
+            schema:
+              $ref: '../schemas/project_note.yaml#/write'
+      responses:
+        '200':
+          $ref: '#/components/ProjectNote'
+  manage:
+    parameters:
+      - $ref: '#/components/ProjectId'
+      - name: note_id
+        description: Unique identifier for the note
+        in: path
+        required: true
+        schema:
+          type: number
+    get:
+      summary: Get Record
+      description: "Retrieve a note by its ID"
+      tags: [Project Notes]
+      responses:
+        '200':
+          $ref: '#/components/ProjectNote'
+        '401': { $ref: '../components/responses.yaml#/Unauthorized' }
+        '404': { $ref: '../components/responses.yaml#/NotFound' }
+    patch:
+      summary: Update Record
+      description: "Update a specific note"
+      tags: [Project Notes]
+      requestBody:
+        $ref: '../components/requests.yaml#/jsonPatch'
+      responses:
+        '200':
+          $ref: '#/components/ProjectNote'
+        '304': { $ref: '../components/responses.yaml#/NoChanges' }
+        '400': { $ref: '../components/responses.yaml#/RequestError' }
+        '401': { $ref: '../components/responses.yaml#/Unauthorized' }
+        '404': { $ref: '../components/responses.yaml#/NotFound' }
+        '409': { $ref: '../components/responses.yaml#/Conflict' }
+    delete:
+      summary: Delete Record
+      description: "Remove a project note"
+      tags: [Project Notes]
+      responses:
+        '204':
+          description: Success
+        '400': { $ref: '../components/responses.yaml#/RequestError' }
+        '401': { $ref: '../components/responses.yaml#/Unauthorized' }

--- a/src/main.yaml
+++ b/src/main.yaml
@@ -87,6 +87,10 @@ paths:
     { '$ref': 'endpoints/project_links.yaml#/paths/collection' }
   /projects/{id}/links/{link_type_id}:
     { '$ref': 'endpoints/project_links.yaml#/paths/manage' }
+  /projects/{id}/notes:
+    { '$ref': 'endpoints/project_notes.yaml#/paths/collection' }
+  /projects/{id}/notes/{note_id}:
+    { '$ref': 'endpoints/project_notes.yaml#/paths/manage' }
   /projects/{id}/dependencies:
     { '$ref': 'endpoints/project_dependencies.yaml#/paths/collection' }
   /projects/{id}/dependencies/{dependency_id}:
@@ -166,6 +170,8 @@ tags:
     description: Endpoint for returning the project fact history for a specific project
   - name: Project Links
     description: Endpoints used to manage links to external resources for a project
+  - name: Project Notes
+    description: Endpoints used to manage notes for a project
   - name: Project Scores
     description: Endpoints detailing information about project scores
   - name: Project URLs
@@ -215,6 +221,7 @@ x-tagGroups:
       - Project Fact Types
       - Project Fact History
       - Project Links
+      - Project Notes
       - Project Scores
       - Project URLs
   - name: Reports

--- a/src/schemas/project_note.yaml
+++ b/src/schemas/project_note.yaml
@@ -1,0 +1,33 @@
+read:
+  title: Project Note
+  description: User generated note about a project
+  type: object
+  properties:
+    id:
+      description: The note identifier
+      type: integer
+    content:
+      description: The note content
+      type: string
+    created_by:
+      description: The user that created the note
+      type: string
+    updated_by:
+      description: The user that most recently modified the note
+      type: string
+      nullable: true
+  required:
+    - content
+    - created_by
+    - id
+
+write:
+  title: Project Note
+  description: User generated note about a project
+  type: object
+  properties:
+    content:
+      description: The note content
+      type: string
+  required:
+    - content


### PR DESCRIPTION
This PR adds the spec for the up-and-coming `/projects/{id}/notes` endpoints as described in https://github.com/AWeber-Imbi/imbi/issues/14