### PR TITLE
Add feed entry type

### DIFF
--- a/src/endpoints/activity_feed.yaml
+++ b/src/endpoints/activity_feed.yaml
@@ -26,6 +26,11 @@ paths:
                   type: object
                   description: Feed Item Entry
                   properties:
+                    type:
+                      description: Describes the format of this entry
+                      type: string
+                      enum:
+                        - ProjectFeedEntry
                     when:
                       description: The timestamp of the entry
                       type: string
@@ -66,6 +71,7 @@ paths:
                   summary: IMBI project changes
                   value:
                     - when: 2021-05-21 16:43:08.639661-04
+                      type: ProjectFeedEntry
                       namespace: Example
                       namespace_id: 1
                       project_id: 1
@@ -76,6 +82,7 @@ paths:
                       email_address: gmr@imbi.co
                       what: updated facts
                     - when: 2021-05-21 16:41:06.423535-04
+                      type: ProjectFeedEntry
                       namespace: Example
                       namespace_id: 1
                       project_id: 1
@@ -86,6 +93,7 @@ paths:
                       email_address: gmr@imbi.co
                       what: updated
                     - when: 2021-05-20 16:30:21.987839-04
+                      type: ProjectFeedEntry
                       namespace: Example
                       namespace_id: 1
                       project_id: 1

--- a/src/endpoints/operations_log.yaml
+++ b/src/endpoints/operations_log.yaml
@@ -94,6 +94,7 @@ paths:
                     - id: 1
                       recorded_at: 2021-05-21T18:39:24.197537
                       recorded_by: gavinr
+                      type: OperationsLogEntry
                       completed_at: ~
                       project_id: 100
                       environment: Testing
@@ -106,6 +107,7 @@ paths:
                     - id: 2
                       recorded_at: 2021-05-21T18:42:00
                       recorded_by: gavinr
+                      type: OperationsLogEntry
                       completed_at: ~
                       project_id: 100
                       environment: Staging
@@ -118,6 +120,7 @@ paths:
                     - id: 3
                       recorded_at: 2021-05-21T19:00:00
                       recorded_by: gavinr
+                      type: OperationsLogEntry
                       completed_at: ~
                       project_id: 100
                       environment: Staging
@@ -228,6 +231,7 @@ components:
         id: 1
         recorded_at: 2021-05-21T18:39:24.197537
         recorded_by: gavinr
+        type: OperationsLogEntry
         completed_at: ~
         project_id: 100
         environment: Testing

--- a/src/endpoints/project_activity_feed.yaml
+++ b/src/endpoints/project_activity_feed.yaml
@@ -22,6 +22,11 @@ paths:
                   type: object
                   description: Feed Item Entry
                   properties:
+                    type:
+                      description: Describes the format of this entry
+                      type: string
+                      enum:
+                        - ProjectFeedEntry
                     when:
                       description: The timestamp of the entry
                       type: string
@@ -50,12 +55,14 @@ paths:
                   summary: Feed entries
                   value:
                     - when: 2021-03-17 23:02:00.912503-04
+                      type: ProjectFeedEntry
                       who: Gavin Roy
                       username: gavinr
                       what: updated fact
                       fact_name: Programming Language
                       value: ES2015+
                     - when: 2021-03-17 22:55:50.865266-04
+                      type: ProjectFeedEntry
                       who: Gavin Roy
                       username: gavinr
                       what: created

--- a/src/schemas/operations_log.yaml
+++ b/src/schemas/operations_log.yaml
@@ -36,6 +36,11 @@ read:
         - Rolled Back
         - Scaled
         - Upgraded
+    type:
+      description: The entry type for this item
+      type: string
+      enum:
+        - OperationsLogEntry
     description:
       description: The single line description of the change
       type: string


### PR DESCRIPTION
This PR adds a new property to the project update feed and ops log entries so that they can have separate data models.  See https://github.com/AWeber-Imbi/imbi-ui/issues/30, https://github.com/AWeber-Imbi/imbi-ui/issues/31, and https://github.com/AWeber-Imbi/imbi-api/pull/30 for related PRs.