### PR TITLE
Fix GET /projects response docs

### DIFF
--- a/src/endpoints/project_facts.yaml
+++ b/src/endpoints/project_facts.yaml
@@ -36,17 +36,8 @@ paths:
             <<: *postContent
       tags: [Project Facts]
       responses:
-        '200':
+        '204':
           description: The request to record the project fact was successful
-          content:
-            application/json: &responsesSuccess
-              schema:
-                $ref: '../schemas/project_fact_type.yaml#/read'
-              examples:
-                record:
-                  $ref: '#/components/examples/read'
-            application/msgpack:
-              <<: *responsesSuccess
         '400': { $ref: '../components/responses.yaml#/RequestError' }
         '401': { $ref: '../components/responses.yaml#/Unauthorized' }
         '409': { $ref: '../components/responses.yaml#/Conflict' }

--- a/src/endpoints/projects.yaml
+++ b/src/endpoints/projects.yaml
@@ -70,29 +70,38 @@ paths:
           content:
             application/json: &responseContent
               schema:
-                type: array
-                items:
-                  $ref: '../schemas/project.yaml#/read'
+                type: object
+                properties:
+                  data:
+                    type: array
+                    items:
+                      $ref: '../schemas/project.yaml#/read'
+                  rows:
+                    type: number
+                    description: |-
+                      Count of projects matching the query parameter filters, ignoring limit. This can be used to determine whether there are more projects to fetch with offset.
               examples:
-                records:
+                record:
                   summary: Multiple project records
                   value:
-                    - id: 1
-                      created_by: test_user
-                      last_modified_by: ~
-                      namespace_id: 1
-                      namespace: Applications
-                      project_type_id: 1
-                      project_type: HTTP API
-                      name: User Service
-                      slug: user
-                      description: |-
-                        The user service is used to manage user specific data, including profiles and content.
-                      environments:
-                        - Testing
-                        - Staging
-                        - Production
-                      archived: false
+                    data:
+                      - id: 1
+                        created_by: test_user
+                        last_modified_by: ~
+                        namespace_id: 1
+                        namespace: Applications
+                        project_type_id: 1
+                        project_type: HTTP API
+                        name: User Service
+                        slug: user
+                        description: |-
+                          The user service is used to manage user specific data, including profiles and content.
+                        environments:
+                          - Testing
+                          - Staging
+                          - Production
+                        archived: false
+                    rows: 1
             application/msgpack:
               <<: *responseContent
         '401': { $ref: '../components/responses.yaml#/Unauthorized' }


### PR DESCRIPTION
The response from GET /projects is an object with two fields: `data` and `rows`, not just an array.