### PR TITLE
Make 'null' a valid value in a patch document

### DIFF
--- a/src/components/schemas.yaml
+++ b/src/components/schemas.yaml
@@ -1,6 +1,12 @@
 ---
+# NB - this is inlined by the swagger bundler that we currently use
+#      so the top-level nullable ends up applying to the root value.
+#      We are also required to have exactly one nullable child in
+#      the oneOf for the OpenAPI validator to allow a null item in
+#      the branch :/
 recursiveType:
   description: The value to add, replace, or test
+  nullable: true
   oneOf:
     - type: array
       items:
@@ -9,7 +15,7 @@ recursiveType:
     - type: number
     - type: object
     - type: string
-  nullable: true
+      nullable: true
 
 jsonPatch:
   title: JSON Patch


### PR DESCRIPTION
Note that we need to specify `nullable=true` twice for it to cover all of the cases -- the root property allows the overall value to be null and we need exactly one nullable path through the `oneOf` as well.

This will address https://github.com/AWeber-Imbi/imbi-api/issues/40 after the openapi.yaml is updated there as well.