### PR TITLE
Add surrogate project identifiers

### DIFF
--- a/src/endpoints/integrations.yaml
+++ b/src/endpoints/integrations.yaml
@@ -32,10 +32,7 @@ paths:
           content:
             application/json:
               schema:
-                type: object
-                properties:
-                  name:
-                    type: string
+                $ref: '../schemas/integration.yaml#/read'
   manage:
     parameters:
       - name: name
@@ -60,5 +57,20 @@ paths:
       tags: [Integrations]
       responses:
         '204': { $ref: '../components/responses.yaml#/RecordRemoved' }
+        '401': { $ref: '../components/responses.yaml#/Unauthorized' }
+        '404': { $ref: '../components/responses.yaml#/NotFound' }
+    patch:
+      description: Update an integration
+      summary: Update an integration
+      tags: [Integrations]
+      requestBody:
+        $ref: '../components/requests.yaml#/jsonPatch'
+      responses:
+        '200':
+          description: Success
+          content:
+            application/json:
+              schema:
+                $ref: '../schemas/integration.yaml#/read'
         '401': { $ref: '../components/responses.yaml#/Unauthorized' }
         '404': { $ref: '../components/responses.yaml#/NotFound' }

--- a/src/endpoints/project_identifiers.yaml
+++ b/src/endpoints/project_identifiers.yaml
@@ -76,3 +76,71 @@ paths:
                 type: object
             application/msgpack:
               <<: *postResponse
+  entry:
+    parameters:
+      - name: id
+        in: path
+        description: Project ID
+        required: true
+        schema:
+          type: integer
+      - name: integration
+        in: path
+        description: Integration name
+        required: true
+        schema:
+          type: string
+    get:
+      description: Retrieve a specific surrogate identifier for the project
+      summary: Get Identifier
+      tags: [Project Facts]
+      responses:
+        '200':
+          description: Success
+          content:
+            application/json: &entryResponse
+              schema:
+                type: object
+                properties:
+                  external_id:
+                    type: string
+                  created_by:
+                    type: string
+                  created_at:
+                    type: string
+                    format: iso8601-timestamp
+                  modified_by:
+                    type: string
+                    nullable: true
+                  modified_at:
+                    type: string
+                    format: iso8601-timestamp
+                    nullable: true
+                required:
+                  - external_id
+                  - created_by
+                  - created_at
+                  - modified_by
+                  - modified_at
+                additionalProperties: true
+            application/msgpack:
+              <<: *entryResponse
+    patch:
+      description: Update a specific surrogate identifier for the project
+      summary: Update identifier
+      requestBody:
+        $ref: '../components/requests.yaml#/jsonPatch'
+      responses:
+        '200':
+          description: Updated identifier
+          content:
+            application/json:
+              <<: *entryResponse
+            application/msgpack:
+              <<: *entryResponse
+    delete:
+      description: Remove the surrogate identifier for the project in a specified integration
+      summary: Remove identifier
+      responses:
+        '204':
+          description: Identifier removed

--- a/src/endpoints/project_identifiers.yaml
+++ b/src/endpoints/project_identifiers.yaml
@@ -1,0 +1,78 @@
+paths:
+  collection:
+    parameters:
+      - name: id
+        in: path
+        description: Project ID
+        required: true
+        schema:
+          type: integer
+    get:
+      description: Retrieve surrogate identifiers for the project
+      summary: Get Identifiers
+      tags: [Project Facts]
+      responses:
+        '200':
+          description: Success
+          content:
+            application/json: &responseContent
+              schema:
+                type: array
+                items:
+                  type: object
+                  properties:
+                    external_id:
+                      type: string
+                    integration_name:
+                      type: string
+                    created_by:
+                      type: string
+                    created_at:
+                      type: string
+                      format: iso8601-timestamp
+                    modified_by:
+                      type: string
+                      nullable: true
+                    modified_at:
+                      type: string
+                      format: iso8601-timestamp
+                      nullable: true
+                  required:
+                    - external_id
+                    - integration_name
+                    - created_by
+                    - created_at
+                    - modified_by
+                    - modified_at
+                  additionalProperties: true
+            application/msgpack:
+              <<: *responseContent
+    post:
+      description: Add a surrogate identifier for a project
+      summary: Add Identifier
+      tags: [Project Facts]
+      requestBody:
+        content:
+          application/json: &postContent
+            schema:
+              type: object
+              properties:
+                external_id:
+                  type: string
+                integration_name:
+                  type: string
+              required:
+                - external_id
+                - integration_name
+              additionalProperties: false
+          application/msgpack:
+            <<: *postContent
+      responses:
+        '200':
+          description: Newly created identifier
+          content:
+            application/json: &postResponse
+              schema:
+                type: object
+            application/msgpack:
+              <<: *postResponse

--- a/src/main.yaml
+++ b/src/main.yaml
@@ -85,6 +85,8 @@ paths:
     { '$ref': 'endpoints/project_fact_history.yaml#/paths/collection'}
   /projects/{id}/feed:
     { '$ref': 'endpoints/project_activity_feed.yaml#/paths/collection' }
+  /projects/{id}/identifiers:
+    { '$ref': 'endpoints/project_identifiers.yaml#/paths/collection'}
   /projects/{id}/links:
     { '$ref': 'endpoints/project_links.yaml#/paths/collection' }
   /projects/{id}/links/{link_type_id}:

--- a/src/main.yaml
+++ b/src/main.yaml
@@ -87,6 +87,8 @@ paths:
     { '$ref': 'endpoints/project_activity_feed.yaml#/paths/collection' }
   /projects/{id}/identifiers:
     { '$ref': 'endpoints/project_identifiers.yaml#/paths/collection'}
+  /projects/{id}/identifiers/{integration}:
+    { '$ref': 'endpoints/project_identifiers.yaml#/paths/entry'}
   /projects/{id}/links:
     { '$ref': 'endpoints/project_links.yaml#/paths/collection' }
   /projects/{id}/links/{link_type_id}:

--- a/src/schemas/integration.yaml
+++ b/src/schemas/integration.yaml
@@ -5,25 +5,10 @@ read:
       type: string
     api_endpoint:
       type: string
-    callback_url:
-      type: string
-    authorization_endpoint:
-      type: string
-    token_endpoint:
-      type: string
-    revoke_endpoint:
-      type: string
-    client_id:
-      type: string
   required:
     [
       name,
       api_endpoint,
-      callback_url,
-      authorization_endpoint,
-      token_endpoint,
-      revoke_endpoint,
-      client_id
     ]
   additionalProperties: false
 
@@ -34,32 +19,13 @@ write:
       type: string
     api_endpoint:
       type: string
-    callback_url:
-      type: string
-    authorization_endpoint:
-      type: string
-    token_endpoint:
-      type: string
-    revoke_endpoint:
+    api_secret:
       type: string
       nullable: true
-    client_id:
-      type: string
-    client_secret:
-      type: string
-      nullable: true
-    public_client:
-      type: boolean
   required:
     [
       name,
       api_endpoint,
-      callback_url,
-      authorization_endpoint,
-      token_endpoint,
-      revoke_endpoint,
-      client_id,
-      client_secret,
-      public_client
+      api_secret,
     ]
   additionalProperties: false


### PR DESCRIPTION
This PR adds `/projects/{id}/identifiers`, `/projects/{id}/identifiers/{name}` endpoints for managing surrogate identifiers for projects. I also reworked the `/integrations` and `/integrations/{id}` endpoints to refer to new data structures. The current endpoints are not used so it is safe to repurpose them. The new data model exposes the tables introduced in [imbi-schema#16](https://github.com/AWeber-Imbi/imbi-schema/pull/16/files).