### PR TITLE
Automation CRUD endpoints

### DIFF
--- a/src/endpoints/automations.yaml
+++ b/src/endpoints/automations.yaml
@@ -103,3 +103,120 @@ sonarqube:
                     type: string
         '400':
           description: Request could not be processed
+
+paths:
+  collection:
+    parameters:
+      - name: integration_name
+        in: path
+        description: Connected application that each automation is related to
+        required: true
+        schema:
+          type: string
+    get:
+      description: Retrieve automations implemented by `integration_name`
+      summary: Get Automations
+      tags: [Automations]
+      responses:
+        '200':
+          description: Success
+          content:
+            application/json:
+              schema:
+                type: array
+                items:
+                  $ref: "../schemas/automations.yaml#/read"
+            application/msgpack:
+              schema:
+                type: array
+                items:
+                  $ref: "../schemas/automations.yaml#/read"
+    post:
+      description: Add an automation
+      summary: Add Automation
+      tags: [Automations]
+      requestBody:
+        content:
+          application/json:
+            schema:
+              $ref: "../schemas/automations.yaml#/write"
+          application/msgpack:
+            schema:
+              $ref: "../schemas/automations.yaml#/write"
+      responses:
+        '200':
+          description: Newly created automation
+          content:
+            application/json:
+              schema:
+                $ref: "../schemas/automations.yaml#/read"
+            application/msgpack:
+              schema:
+                $ref: "../schemas/automations.yaml#/read"
+        '400': { $ref: "../components/responses.yaml#/RequestError" }
+        '401': { $ref: "../components/responses.yaml#/Unauthorized" }
+        '409': { $ref: "../components/responses.yaml#/Conflict" }
+  manage:
+    parameters:
+      - name: integration_name
+        in: path
+        description: Application that implements this automation
+        required: true
+        schema:
+          type: string
+      - name: automation_name
+        in: path
+        description: Assigned slug or name of the automation
+        required: true
+        schema:
+          type: string
+    get:
+      summary: Get Automation
+      description: |
+        Retrieve an automation by its slug, name, or surrogate ID
+      tags: [Automations]
+      responses:
+        '200':
+          description: Record details
+          content:
+            application/json:
+              schema:
+                $ref: "../schemas/automations.yaml#/read"
+            application/msgpack:
+              schema:
+                $ref: "../schemas/automations.yaml#/read"
+        '400': { $ref: "../components/responses.yaml#/RequestError" }
+        '401': { $ref: "../components/responses.yaml#/Unauthorized" }
+        '404': { $ref: "../components/responses.yaml#/NotFound" }
+    delete:
+      summary: Delete Automation
+      description: |
+        Delete an automation by its slug, name, or surrogate ID
+      tags: [Automations]
+      responses:
+        '204': { $ref: "../components/responses.yaml#/RecordRemoved" }
+        '400': { $ref: "../components/responses.yaml#/RequestError" }
+        '401': { $ref: "../components/responses.yaml#/Unauthorized" }
+        '404': { $ref: "../components/responses.yaml#/NotFound" }
+    patch:
+      summary: Update Automation
+      description: |
+        Update an automation by its slug, name, or surrogate ID
+      tags: [Automations]
+      requestBody:
+        $ref: "../components/requests.yaml#/jsonPatch"
+      responses:
+        '200':
+          description: Updated Record
+          content:
+            application/json:
+              schema:
+                $ref: "../schemas/automations.yaml#/read"
+            application/msgpack:
+              schema:
+                $ref: "../schemas/automations.yaml#/read"
+        '304': { $ref: "../components/responses.yaml#/NoChanges" }
+        '400': { $ref: "../components/responses.yaml#/RequestError" }
+        '401': { $ref: "../components/responses.yaml#/Unauthorized" }
+        '404': { $ref: "../components/responses.yaml#/NotFound" }
+        '409': { $ref: "../components/responses.yaml#/Conflict" }

--- a/src/endpoints/integration_notifications.yaml
+++ b/src/endpoints/integration_notifications.yaml
@@ -9,7 +9,7 @@ paths:
     get:
       description: Retrieve the collection of notifications defined for an integration
       summary: Get notifications
-      tags: [Integrations]
+      tags: [Notifications]
       responses:
         '200':
           description: Success
@@ -22,7 +22,7 @@ paths:
     post:
       description: Add a new notification to an integration
       summary: Add notification
-      tags: [Integrations]
+      tags: [Notifications]
       requestBody:
         description: Notification details
         content:
@@ -54,7 +54,7 @@ paths:
     get:
       description: Retrieve a specific notification by name
       summary: Fetch a single notification
-      tags: [Integrations]
+      tags: [Notifications]
       responses:
         '200':
           description: Success
@@ -65,7 +65,7 @@ paths:
     delete:
       description: Remove the specified notification
       summary: Delete a notification
-      tags: [Integrations]
+      tags: [Notifications]
       responses:
         '204': { $ref: '../components/responses.yaml#/RecordRemoved' }
         '401': { $ref: '../components/responses.yaml#/Unauthorized' }
@@ -73,7 +73,7 @@ paths:
     patch:
       description: Update a notification
       summary: Update a notification
-      tags: [Integrations]
+      tags: [Notifications]
       requestBody:
         $ref: '../components/requests.yaml#/jsonPatch'
       responses:

--- a/src/endpoints/notification_filters.yaml
+++ b/src/endpoints/notification_filters.yaml
@@ -14,7 +14,7 @@ paths:
     get:
       description: Retrieve the collection of filters for a notification
       summary: Get notification filters
-      tags: [Integrations]
+      tags: [Notifications]
       responses:
         '200':
           description: Success
@@ -27,7 +27,7 @@ paths:
     post:
       description: Add a new filter to a notification
       summary: Add notification filter
-      tags: [Integrations]
+      tags: [Notifications]
       requestBody:
         description: Filter details
         content:
@@ -64,7 +64,7 @@ paths:
     get:
       description: Retrieve a specific filter from a notification by name
       summary: Fetch a notification filter
-      tags: [Integrations]
+      tags: [Notifications]
       responses:
         '200':
           description: Success
@@ -75,7 +75,7 @@ paths:
     delete:
       description: Remove the filter from the notification
       summary: Delete a notification filter
-      tags: [Integrations]
+      tags: [Notifications]
       responses:
         '204': { $ref: '../components/responses.yaml#/RecordRemoved' }
         '401': { $ref: '../components/responses.yaml#/Unauthorized' }
@@ -83,7 +83,7 @@ paths:
     patch:
       description: Update a notification filter
       summary: Update a notification filter
-      tags: [Integrations]
+      tags: [Notifications]
       requestBody:
         $ref: '../components/requests.yaml#/jsonPatch'
       responses:

--- a/src/endpoints/notification_rules.yaml
+++ b/src/endpoints/notification_rules.yaml
@@ -14,7 +14,7 @@ paths:
     get:
       description: Retrieve the collection of rules for a notification
       summary: Get notification rules
-      tags: [Integrations]
+      tags: [Notifications]
       responses:
         '200':
           description: Success
@@ -27,7 +27,7 @@ paths:
     post:
       description: Add a new rule to a notification
       summary: Add notification rule
-      tags: [Integrations]
+      tags: [Notifications]
       requestBody:
         description: Rule details
         content:
@@ -64,7 +64,7 @@ paths:
     get:
       description: Retrieve a specific rule from a notification by name
       summary: Fetch a notification rule
-      tags: [Integrations]
+      tags: [Notifications]
       responses:
         '200':
           description: Success
@@ -75,7 +75,7 @@ paths:
     delete:
       description: Remove a rule from the notification
       summary: Delete a notification rule
-      tags: [Integrations]
+      tags: [Notifications]
       responses:
         '204': { $ref: '../components/responses.yaml#/RecordRemoved' }
         '401': { $ref: '../components/responses.yaml#/Unauthorized' }
@@ -83,7 +83,7 @@ paths:
     patch:
       description: Update a notification rule
       summary: Update a notification rule
-      tags: [Integrations]
+      tags: [Notifications]
       requestBody:
         $ref: '../components/requests.yaml#/jsonPatch'
       responses:

--- a/src/endpoints/project_identifiers.yaml
+++ b/src/endpoints/project_identifiers.yaml
@@ -128,6 +128,7 @@ paths:
     patch:
       description: Update a specific surrogate identifier for the project
       summary: Update identifier
+      tags: [Project Facts]
       requestBody:
         $ref: '../components/requests.yaml#/jsonPatch'
       responses:
@@ -141,6 +142,7 @@ paths:
     delete:
       description: Remove the surrogate identifier for the project in a specified integration
       summary: Remove identifier
+      tags: [Project Facts]
       responses:
         '204':
           description: Identifier removed

--- a/src/main.yaml
+++ b/src/main.yaml
@@ -204,6 +204,8 @@ tags:
     description: Endpoints used for retrieving settings for the Imbi UI
   - name: Integrations
     description: Endpoints used to retrieve information about applications that Imbi is integrated with
+  - name: Notifications
+    description: Endpoints used for integrating Imbi with webhooks from other applications
   - name: Monitoring & Metrics
     description: |-
       Endpoints used for health checking, service status, and service metrics
@@ -223,13 +225,17 @@ x-tagGroups:
     tags:
       - Cookie Cutters
       - Environments
-      - Integrations
       - Namespaces
       - Fact Types
       - Fact Type Enums
       - Fact Type Ranges
       - Project Link Types
       - Project Types
+  - name: Integrations
+    tags:
+      - Integrations
+      - Notifications
+      - Automations
   - name: Operations Log
     tags:
       - Operations Log
@@ -252,7 +258,6 @@ x-tagGroups:
       - User
   - name: UI Specific
     tags:
-      - Automations
       - Dashboard
       - Settings
   - name: Other

--- a/src/main.yaml
+++ b/src/main.yaml
@@ -51,6 +51,10 @@ paths:
   /namespaces/{id}: { $ref: 'endpoints/namespace.yaml#/paths/manage' }
   /integrations: { $ref: 'endpoints/integrations.yaml#/paths/collection' }
   /integrations/{name}: { $ref: 'endpoints/integrations.yaml#/paths/manage' }
+  /integrations/{integration_name}/automations:
+    { $ref: 'endpoints/automations.yaml#/paths/collection'}
+  /integrations/{integration_name}/automations/{automation_name}:
+    { $ref: 'endpoints/automations.yaml#/paths/manage'}
   /integrations/{integration_name}/notifications:
     { $ref: 'endpoints/integration_notifications.yaml#/paths/collection' }
   /integrations/{integration_name}/notifications/{notification_name}:

--- a/src/schemas/automations.yaml
+++ b/src/schemas/automations.yaml
@@ -1,0 +1,116 @@
+read:
+  type: object
+  properties:
+    id:
+      description: "Surrogate ID for this automation"
+      type: integer
+    name:
+      description: "Human-readable name for this automation"
+      type: string
+    slug:
+      description: "Machine-readable slug"
+      type: string
+      pattern: "^[a-z0-9][-_a-z0-9]*[a-z0-9]$"
+      minLength: 2
+    integration_name:
+      description: "The name of the integration that implements this automation"
+      type: string
+    callable: &automationCallable
+      description: |
+        Identifies what to invoke for this automation.
+        
+        This identifies which python function to invoke inside of the running
+        Imbi instance. It uses the [common import string] syntax.
+        
+        [common import string]: https://docs.pydantic.dev/latest/api/types/#pydantic.types.ImportString
+      type: string
+    categories: &automationCategories
+      description: "Which actions is this automation valid for?"
+      type: array
+      items:
+        type: string
+        enum:
+          - create-project
+    applies_to:
+      description: "Project type slugs that this automation can be run for"
+      type: array
+      items:
+        type: string
+    depends_on:
+      description: "Slugs of other automations that are required for this automation to be run"
+      type: array
+      items:
+        type: string
+    created_at:
+      type: string
+      format: date-time
+    created_by:
+      type: string
+    last_modified_at:
+      type: string
+      format: date-time
+      nullable: true
+    last_modified_by:
+      type: string
+      nullable: true
+  example:
+    id: 1
+    name: "Create project"
+    slug: "github-create-project"
+    integration_name: "GitHub"
+    callable: "imbi.endpoints.integrations.automations.do_nothing"
+    categories:
+      - "create-project"
+    applies_to:
+      - "http-api"
+    depends_on: []
+    created_at: "2024-02-27T21:05:46+0000"
+    created_by: "me"
+    last_modified_at: null
+    last_modified_by: null
+
+write:
+  type: object
+  properties:
+    name:
+      description: "Human-readable name for this automation"
+      type: string
+    categories:
+      <<: *automationCategories
+    callable:
+      allOf:
+        - *automationCallable
+        - type: string
+          default: "imbi.endpoints.integrations.automations.do_nothing"
+    applies_to:
+      description: "List of project types that this automation is valid for"
+      type: array
+      items:
+        oneOf:
+          - type: string
+            title: slug
+            description: Identifies the project type using its slug
+          - type: integer
+            title: ID
+            description: Identifies the project type using its unique ID
+    depends_on:
+      description: "List of other automations that are required for this automation to run"
+      type: array
+      items:
+        oneOf:
+          - type: string
+            title: slug
+            description: Identifies the automation using its slug
+          - type: integer
+            title: ID
+            description: Identifies the automation using its surrogate ID
+  required:
+    - name
+    - categories
+    - applies_to
+  example:
+    name: "Create project"
+    categories:
+      - "create-project"
+    applies_to:
+      - "http-api"


### PR DESCRIPTION
This PR adds the endpoint specifications for the new endpoints that populate the entities from https://github.com/AWeber-Imbi/imbi-schema/pull/19. The endpoints are more complex than our more-anemic CRUD endpoints. Instead of introducing a CRUD endpoint for an _Automation_ and accessory endpoints for associating the Automation with project types and dependent automations, I switched to using a complex document with nested identifiers.

<details>
<summary>Example of dependent automations</summary>
Both automations are implemented by the same integration. The second automation (`gitlab-first-commit`) requires that the first on (`gitlab-create-project`) will be run as well.

```json
[
  {
    "id": 1,
    "name": "Create project",
    "slug": "gitlab-create-project",
    "integration_name": "gitlab",
    "callable": "imbi.endpoints.integrations.automations.do_nothing",
    "categories": [
      "create-project"
    ],
    "applies_to": [
      "api",
      "consumers"
    ],
    "depends_on": [],
    "created_by": "test",
    "created_at": "2024-02-27T21:14:25.549146Z",
    "last_modified_by": null,
    "last_modified_at": null
  },
  {
    "id": 3,
    "name": "First commit",
    "slug": "gitlab-first-commit",
    "integration_name": "gitlab",
    "callable": "imbi.endpoints.integrations.automations.do_nothing",
    "categories": [
      "create-project"
    ],
    "applies_to": [
      "api",
      "consumers"
    ],
    "depends_on": [
      "gitlab-create-project"
    ],
    "created_by": "test",
    "created_at": "2024-02-28T14:19:06.726882Z",
    "last_modified_by": null,
    "last_modified_at": null
  }
]
```
</details>

## IDs and slugs

The complex document model is a little more difficult to implement when it comes to `PATCH` since we are sticking with JSON patches. I included some additional sugar in the schema so that you can use IDs and slugs in the associative portions (`applies_to` and `depends_on`). This simplifies the API usage considerably IMO. For example, the following JSON patch would make the `gitlab-first-commit` automation applicable to some project type by its integer ID since the UI usually has them handy.

```json
[ {"op":"add", "path": "/applies_to/-", "value": 13} ]
```

The same update could be accomplished using the project-type slug:

```json
[ {"op":"add", "path": "/applies_to/-", "value": "web-app"} ]
```

### in the URL too!

The new URL structure also accepts the automation ID, name, or slug in the path. So the following three would patch the same resource.

```
PATCH /integrations/gitlab/automations/create-project
PATCH /integrations/gitlab/automations/gitlab-create-project
PATCH /integrations/gitlab/automations/1
```