### PR TITLE
Endpoint for SSM config and aws_ssm_slug to namespace endpoint

### DIFF
--- a/src/endpoints/namespace.yaml
+++ b/src/endpoints/namespace.yaml
@@ -24,6 +24,7 @@ paths:
                       slug: PSE
                       icon_class: fas fa-blind
                       sentry_team_slug: pse
+                      aws_ssm_slug: pse
                       maintained_by:
                         - Developers
                         - Operations
@@ -113,6 +114,7 @@ components:
           - Developers
           - Operations
         sentry_team_slug: pse
+        aws_ssm_slug: pse
     write:
       summary: A full namespace record
       value:
@@ -120,6 +122,7 @@ components:
         slug: PSE
         icon_class: fas fa-blind
         sentry_team_slug: pse
+        aws_ssm_slug: pse
         maintained_by:
           - Developers
           - Operations

--- a/src/endpoints/project_configuration_ssm.yaml
+++ b/src/endpoints/project_configuration_ssm.yaml
@@ -22,19 +22,21 @@ paths:
                 records:
                   value:
                     - name: "/foo/bar/baz"
-                      type: String
                       values:
                         - environment: Testing
                           value: "42"
+                          type: String
                         - environment: Production
                           value: "9001"
+                          type: String
                     - name: "biz/bap/boop"
-                      type: SecureString
                       values:
                         - environment: Testing
                           value: "password"
+                          type: SecureString
                         - environment: Production
                           value: "password123$"
+                          type: SecureString
             application/msgpack:
               <<: *collectionResponse
         '401': { $ref: '../components/responses.yaml#/Unauthorized' }

--- a/src/endpoints/project_configuration_ssm.yaml
+++ b/src/endpoints/project_configuration_ssm.yaml
@@ -1,0 +1,41 @@
+paths:
+  collection:
+    parameters:
+      - name: id
+        in: path
+        description: ID of the project to get parameters for
+        required: true
+        schema:
+          type: number
+    get:
+      description: Retrieve the SSM parameters for the project
+      summary: Get SSM Parameters
+      tags: [Project Configuration]
+      responses:
+        '200':
+          description: Success
+          content:
+            application/json: &collectionResponse
+              schema:
+                $ref: '../schemas/project_configuration_ssm.yaml#/read'
+              examples:
+                records:
+                  value:
+                    - name: "/foo/bar/baz"
+                      type: String
+                      values:
+                        - environment: Testing
+                          value: "42"
+                        - environment: Production
+                          value: "9001"
+                    - name: "biz/bap/boop"
+                      type: SecureString
+                      values:
+                        - environment: Testing
+                          value: "password"
+                        - environment: Production
+                          value: "password123$"
+            application/msgpack:
+              <<: *collectionResponse
+        '401': { $ref: '../components/responses.yaml#/Unauthorized' }
+        '404': { $ref: '../components/responses.yaml#/NotFound' }

--- a/src/endpoints/projects.yaml
+++ b/src/endpoints/projects.yaml
@@ -101,6 +101,7 @@ paths:
                           - Staging
                           - Production
                         archived: false
+                        configuration_type: ssm
                     rows: 1
             application/msgpack:
               <<: *responseContent
@@ -212,6 +213,7 @@ components:
           - Staging
           - Production
         archived: false
+        configuration_type: ssm
     write:
       summary: An example of the payload for creating a record
       value:

--- a/src/main.yaml
+++ b/src/main.yaml
@@ -93,6 +93,8 @@ paths:
   /project-types/{id}: { $ref: 'endpoints/project_type.yaml#/paths/manage' }
   /projects: { '$ref': 'endpoints/projects.yaml#/paths/collection' }
   /projects/{id}: { '$ref': 'endpoints/projects.yaml#/paths/manage' }
+  /projects/{id}/configuration/ssm:
+    { '$ref': 'endpoints/project_configuration_ssm.yaml#/paths/collection' }
   /projects/{id}/facts:
     { '$ref': 'endpoints/project_facts.yaml#/paths/collection' }
   /projects/{id}/fact-types:
@@ -184,6 +186,8 @@ tags:
     description: Endpoints used for the management of projects
   - name: Project Activity Feed
     description: Endpoints that detail activity on a project
+  - name: Project Configuration
+    description: Endpoints to manage project configuration
   - name: Project Dependencies
     description: Endpoints used to manage the relationships of projects to other projects
   - name: Project Facts
@@ -246,6 +250,7 @@ x-tagGroups:
   - name: Project Management
     tags:
       - Projects
+      - Project Configuration
       - Project Dependencies
       - Project Facts
       - Project Fact Types

--- a/src/schemas/namespace.yaml
+++ b/src/schemas/namespace.yaml
@@ -39,6 +39,10 @@ read:
       description: Optional ID of associated PagerDuty escalation policy
       type: string
       nullable: true
+    aws_ssm_slug:
+      description: Optional slug of the namespace in the AWS SSM path
+      type: string
+      nullable: true
   required:
     - name
     - slug
@@ -75,6 +79,10 @@ write:
       nullable: true
     pagerduty_policy:
       description: Optional ID of associated PagerDuty escalation policy
+      type: string
+      nullable: true
+    aws_ssm_slug:
+      description: Optional slug of the namespace in the AWS SSM path
       type: string
       nullable: true
   required:

--- a/src/schemas/project.yaml
+++ b/src/schemas/project.yaml
@@ -60,6 +60,10 @@ read:
       description: Optional ID for the project in PagerDuty
       type: string
       nullable: true
+    configuration_type:
+      description: Optional configuration system for the project
+      type: string
+      nullable: true
   additionalProperties: false
 
 write:

--- a/src/schemas/project_configuration_ssm.yaml
+++ b/src/schemas/project_configuration_ssm.yaml
@@ -1,0 +1,40 @@
+read:
+  title: Project SSM Configuration
+  description: SSM parameters for the project
+  type: array
+  items:
+    description: The SSM parameter
+    type: object
+    properties:
+      name:
+        description: The SSM parameter path
+        type: string
+      type:
+        description: The SSM parameter type
+        type: string
+        enum:
+          - String
+          - SecureString
+          - StringList
+      values:
+        description: The parameter values in each environment
+        type: array
+        items:
+          description: The parameter value in this environment
+          type: object
+          properties:
+            environment:
+              description: The environment the parameter exists in
+              type: string
+            value:
+              description: The parameter value
+              type: string
+          additionalProperties: false
+          required:
+            - environment
+            - value
+    additionalProperties: false
+    required:
+      - name
+      - type
+      - values

--- a/src/schemas/project_configuration_ssm.yaml
+++ b/src/schemas/project_configuration_ssm.yaml
@@ -9,13 +9,6 @@ read:
       name:
         description: The SSM parameter path
         type: string
-      type:
-        description: The SSM parameter type
-        type: string
-        enum:
-          - String
-          - SecureString
-          - StringList
       values:
         description: The parameter values in each environment
         type: array
@@ -29,12 +22,19 @@ read:
             value:
               description: The parameter value
               type: string
+            type:
+              description: The SSM parameter type
+              type: string
+              enum:
+                - String
+                - SecureString
+                - StringList
           additionalProperties: false
           required:
             - environment
             - value
+            - type
     additionalProperties: false
     required:
       - name
-      - type
       - values


### PR DESCRIPTION
This adds a new endpoint to fetch AWS SSM parameters for a given project.

It also adds an optional `aws_ssm_slug` to the namespace schema so that administrators can specify a custom version of the namespace for the SSM parameter path prefix (such as lowercasing the slug value...)