### PR TITLE
Add GET /reports/component-usage

### DIFF
--- a/src/endpoints/component_usage_report.yaml
+++ b/src/endpoints/component_usage_report.yaml
@@ -1,0 +1,61 @@
+paths:
+  collection:
+    get:
+      description: Report of all defined components
+      summary: Component Usage
+      tags: [Reports]
+      responses:
+        '200':
+          description: Success
+          content:
+            application/json: &componentUsageContent
+              schema:
+                type: array
+                items:
+                  type: object
+                  description: Single component usage report
+                  properties:
+                    name:
+                      description: Component name
+                      type: string
+                    package_url:
+                      description: |
+                        Unique identifier for the component following the
+                        [purl spec](https://github.com/package-url/purl-spec)
+                      type: string
+                      pattern: "^pkg:"
+                    active_version:
+                      description: Optional semantic version range that is
+                        considered the "current" version
+                      type: string
+                      nullable: true
+                    status:
+                      description: "Status for *all* versions of this component"
+                      type: string
+                      enum:
+                        - Active
+                        - Deprecated
+                        - Forbidden
+                    project_count:
+                      description: "Number of projects using this component"
+                      type: number
+                    version_count:
+                      description: "Number of known versions of this component"
+                      type: number
+                  required:
+                    - active_version
+                    - name
+                    - package_url
+                    - project_count
+                    - status
+                    - version_count
+                  example:
+                    active_version: "~0.21"
+                    name: "imbi"
+                    package_url: "pkg:pypi:imbi"
+                    status: Active
+                    project_count: 1
+                    version_count: 12
+            application/msgpack:
+              <<: *componentUsageContent
+        '401': { $ref: '../components/responses.yaml#/Unauthorized' }

--- a/src/main.yaml
+++ b/src/main.yaml
@@ -133,6 +133,8 @@ paths:
     { '$ref': 'endpoints/project_urls.yaml#/paths/manage' }
   /projects/build-search-index:
     { '$ref': 'endpoints/projects.yaml#/paths/search' }
+  /reports/component-usage:
+    { $ref: 'endpoints/component_usage_report.yaml#/paths/collection' }
   /reports/namespace-shs-history:
     { $ref: 'endpoints/namespace_shs_history.yaml#/paths/collection' }
   /reports/system-shs-history:


### PR DESCRIPTION
This describes the Component Usage report that is implemented in https://github.com/AWeber-Imbi/imbi-api/pull/91. As usual, the built OpenAPI spec is included in that PR.