### PR TITLE
Remove uri format from project link URLs

### DIFF
--- a/package.json
+++ b/package.json
@@ -38,5 +38,6 @@
   },
   "lint-staged": {
     "*.{js,json,yaml}": "prettier --write"
-  }
+  },
+  "packageManager": "yarn@1.22.22"
 }

--- a/src/schemas/project_link.yaml
+++ b/src/schemas/project_link.yaml
@@ -24,7 +24,6 @@ read:
     url:
       description: The link URL
       type: string
-      format: uri
   additionalProperties: false
 
 write:
@@ -41,7 +40,6 @@ write:
     url:
       description: The link URL
       type: string
-      format: uri
   required:
     - project_id
     - link_type_id


### PR DESCRIPTION
The OpenAPI validator that we are currently using rejects the long URLs for linking to logs in our backend provider.