### PR TITLE
Use updated SSM schema & add PATCH endpoint

### DIFF
--- a/src/endpoints/project_configuration_ssm.yaml
+++ b/src/endpoints/project_configuration_ssm.yaml
@@ -55,10 +55,13 @@ paths:
               $ref: '../schemas/project_configuration_ssm.yaml#/write'
             example:
               name: "foo/bar/baz"
-              type: String
               values:
-                Testing: "42"
-                Production: "9001"
+                Testing:
+                  value: "42"
+                  type: String
+                Production:
+                  value: "9001"
+                  type: String
           application/msgpack:
              <<: *postBody
       responses:

--- a/src/endpoints/project_configuration_ssm.yaml
+++ b/src/endpoints/project_configuration_ssm.yaml
@@ -89,3 +89,29 @@ paths:
         '204': { $ref: '../components/responses.yaml#/RecordRemoved' }
         '401': { $ref: '../components/responses.yaml#/Unauthorized' }
         '404': { $ref: '../components/responses.yaml#/NotFound' }
+  record:
+    parameters:
+      - name: id
+        in: path
+        description: ID of the project to get parameters for
+        required: true
+        schema:
+          type: number
+      - name: name
+        in: path
+        description: The URL-encoded SSM name of the parameter
+        required: true
+        schema:
+          type: string
+    patch:
+      description: Update an SSM parameter with a specific name
+      summary: Update SSM param
+      tags: [ Project Configuration ]
+      requestBody:
+        $ref: '../components/requests.yaml#/jsonPatch'
+      responses:
+        '200':
+          description: Success
+        '400': { $ref: '../components/responses.yaml#/RequestError' }
+        '401': { $ref: '../components/responses.yaml#/Unauthorized' }
+        '404': { $ref: '../components/responses.yaml#/NotFound' }

--- a/src/endpoints/project_configuration_ssm.yaml
+++ b/src/endpoints/project_configuration_ssm.yaml
@@ -21,22 +21,24 @@ paths:
               examples:
                 records:
                   value:
-                    - name: "/foo/bar/baz"
+                    - name: "foo/bar/baz"
                       values:
-                        - environment: Testing
+                        Testing:
                           value: "42"
                           type: String
-                        - environment: Production
+                        Production:
                           value: "9001"
                           type: String
+                      self: "https://imbi.com/project/3/configuration/ssm/foo%2Fbar%2Fbaz"
                     - name: "biz/bap/boop"
                       values:
-                        - environment: Testing
+                        Testing:
                           value: "password"
                           type: SecureString
-                        - environment: Production
+                        Production:
                           value: "password123$"
                           type: SecureString
+                      self: "https://imbi.com/project/3/configuration/ssm/biz%2Fbap%2Fboop"
             application/msgpack:
               <<: *collectionResponse
         '401': { $ref: '../components/responses.yaml#/Unauthorized' }

--- a/src/main.yaml
+++ b/src/main.yaml
@@ -99,6 +99,8 @@ paths:
     { '$ref': 'endpoints/project_components.yaml#/paths/collection' }
   /projects/{id}/configuration/ssm:
     { '$ref': 'endpoints/project_configuration_ssm.yaml#/paths/collection' }
+  /projects/{id}/configuration/ssm/{name}:
+    { '$ref': 'endpoints/project_configuration_ssm.yaml#/paths/record' }
   /projects/{id}/facts:
     { '$ref': 'endpoints/project_facts.yaml#/paths/collection' }
   /projects/{id}/fact-types:

--- a/src/schemas/project_configuration_ssm.yaml
+++ b/src/schemas/project_configuration_ssm.yaml
@@ -1,3 +1,24 @@
+param: &param
+  description: The parameter values in each environment
+  type: object
+  additionalProperties:
+    type: object
+    properties:
+      value:
+        description: The parameter value
+        type: string
+      type:
+        description: The SSM parameter type
+        type: string
+        enum:
+          - String
+          - SecureString
+          - StringList
+    additionalProperties: false
+    required:
+      - value
+      - type
+
 read:
   title: Project SSM Configuration
   description: SSM parameters for the project
@@ -10,25 +31,7 @@ read:
         description: The SSM parameter path
         type: string
       values:
-        description: The parameter values in each environment
-        type: object
-        additionalProperties:
-          type: object
-          properties:
-            value:
-              description: The parameter value
-              type: string
-            type: &type
-              description: The SSM parameter type
-              type: string
-              enum:
-                - String
-                - SecureString
-                - StringList
-          additionalProperties: false
-          required:
-            - value
-            - type
+        <<: *param
       self:
         description: URL referring to this parameter for this project, with SSM name URL-encoded
         type: string
@@ -46,17 +49,11 @@ write:
     name:
       description: The SSM parameter path after the project prefix
       type: string
-    type:
-      <<: *type
     values:
-      description: The parameter values in each environment
-      type: object
-      additionalProperties:
-        type: string
+      <<: *param
   additionalProperties: false
   required:
     - name
-    - type
     - values
 
 delete:

--- a/src/schemas/project_configuration_ssm.yaml
+++ b/src/schemas/project_configuration_ssm.yaml
@@ -11,14 +11,10 @@ read:
         type: string
       values:
         description: The parameter values in each environment
-        type: array
-        items:
-          description: The parameter value in this environment
+        type: object
+        additionalProperties:
           type: object
           properties:
-            environment:
-              description: The environment the parameter exists in
-              type: string
             value:
               description: The parameter value
               type: string
@@ -31,11 +27,14 @@ read:
                 - StringList
           additionalProperties: false
           required:
-            - environment
             - value
             - type
+      self:
+        description: URL referring to this parameter for this project, with SSM name URL-encoded
+        type: string
     additionalProperties: false
     required:
+      - self
       - name
       - values
 


### PR DESCRIPTION
This updates the GET and POST endpoints to use the updated SSM schema with an object with environment keys, and then a nested object with the type and value.

The PATCH endpoint expects JSON-patch to update the type and/or values of params, in addition to deleting or adding new ones.