### PR TITLE
Add optional project info in dependency endpoint

### DIFF
--- a/src/endpoints/project_dependencies.yaml
+++ b/src/endpoints/project_dependencies.yaml
@@ -55,7 +55,7 @@ paths:
         required: true
         schema:
           type: number
-      - name: includes
+      - name: include
         in: query
         description: Optionally expand the dependent project
         schema:

--- a/src/endpoints/project_dependencies.yaml
+++ b/src/endpoints/project_dependencies.yaml
@@ -55,6 +55,13 @@ paths:
         required: true
         schema:
           type: number
+      - name: includes
+        in: query
+        description: Optionally expand the dependent project
+        schema:
+          type: string
+          enum:
+            - dependency
   manage:
     get:
       summary: Get Record

--- a/src/schemas/project_dependency.yaml
+++ b/src/schemas/project_dependency.yaml
@@ -12,7 +12,22 @@ read:
     dependency_id:
       description: The ID of the project that is depended upon
       type: number
-  additionalProperties: false
+    dependency:
+      description: Optional project information of the dependency
+      type: object
+      properties:
+        id:
+          description: The ID of the project that is depended upon
+          type: number
+        name:
+          description: The project name
+          type: string
+        namespace_id:
+          description: The project namespace ID
+          type: number
+        project_type_id:
+          description: The project type ID
+          type: number
 
 write:
   title: Project


### PR DESCRIPTION
This adds an optional query string parameter `includes` for requesters to specify they want expanded project information about the dependencies.