### PR TITLE
Add automations to project dependencies

### DIFF
--- a/src/endpoints/project_dependencies.yaml
+++ b/src/endpoints/project_dependencies.yaml
@@ -77,6 +77,17 @@ paths:
       summary: Delete Record
       description: Remove a project dependency record
       tags: [Project Dependencies]
+      requestBody:
+        description: Specify optional automation slugs to run
+        content:
+          application/json: &deleteContent
+            schema:
+              $ref: '../schemas/project_dependency.yaml#/delete'
+            examples:
+              record:
+                $ref: '#/components/examples/delete'
+          application/msgpack:
+            <<: *deleteContent
       responses:
         '204': { $ref: '../components/responses.yaml#/RecordRemoved' }
         '401': { $ref: '../components/responses.yaml#/Unauthorized' }
@@ -107,6 +118,10 @@ components:
       summary: The payload used when creating a project dependency
       value:
         dependency_id: 1
+    delete:
+      summary: Optional automations to run
+      value:
+        automations: ['create-pagerduty-dependency']
 
   responses:
     Success:

--- a/src/endpoints/project_dependencies.yaml
+++ b/src/endpoints/project_dependencies.yaml
@@ -20,9 +20,11 @@ paths:
                   summary: Multiple records
                   value:
                     - project_id: 2
+                      created_at: 1964-01-01T19:11:11.000Z
                       created_by: test_user
                       dependency_id: 1
                     - project_id: 3
+                      created_at: 1964-01-01T19:11:11.000Z
                       created_by: test_user
                       dependency_id: 1
             application/msgpack:

--- a/src/schemas/automations.yaml
+++ b/src/schemas/automations.yaml
@@ -31,6 +31,8 @@ read:
         type: string
         enum:
           - create-project
+          - create-project-dependency
+          - remove-project-dependency
     applies_to:
       description: "Project type slugs that this automation can be run for"
       type: array

--- a/src/schemas/project_dependency.yaml
+++ b/src/schemas/project_dependency.yaml
@@ -38,7 +38,7 @@ write:
   description: A record that indicates one project is dependent upon another
   type: object
   properties:
-    automations:
+    automations: &automations
       description: List of automations to run while creating the project dependency
       type: array
       items:
@@ -49,4 +49,13 @@ write:
       type: number
   required:
     - dependency_id
+  additionalProperties: false
+
+delete:
+  title: Project Dependency
+  description: A record that indicates one project is dependent upon another
+  type: object
+  properties:
+    automations:
+      <<: *automations
   additionalProperties: false

--- a/src/schemas/project_dependency.yaml
+++ b/src/schemas/project_dependency.yaml
@@ -1,5 +1,5 @@
 read:
-  title: Project
+  title: Project Dependency
   description: A record that indicates one project is dependent upon another
   type: object
   properties:
@@ -34,7 +34,7 @@ read:
           type: number
 
 write:
-  title: Project
+  title: Project Dependency
   description: A record that indicates one project is dependent upon another
   type: object
   properties:

--- a/src/schemas/project_dependency.yaml
+++ b/src/schemas/project_dependency.yaml
@@ -6,6 +6,10 @@ read:
     project_id:
       description: The ID of the project that has the dependency
       type: number
+    created_at:
+      description: The timestamp when the dependency was created
+      type: string
+      format: iso8601-timestamp
     created_by:
       description: The username indicating who created the record
       type: string

--- a/src/schemas/project_dependency.yaml
+++ b/src/schemas/project_dependency.yaml
@@ -38,6 +38,12 @@ write:
   description: A record that indicates one project is dependent upon another
   type: object
   properties:
+    automations:
+      description: List of automations to run while creating the project dependency
+      type: array
+      items:
+        type: string
+      nullable: true
     dependency_id:
       description: The ID of the project that is depended upon
       type: number


### PR DESCRIPTION
This adds optional `automations` fields to the request payload for the POST and DELETE endpoints of project dependencies. It specifies the two new automation types `create-project-dependency` and `remove-project-dependency`. It also adds missing `created_at` in the GET endpoint.