### PR TITLE
Update /projects/{id}/components response

### DIFF
--- a/src/endpoints/project_components.yaml
+++ b/src/endpoints/project_components.yaml
@@ -36,22 +36,14 @@ paths:
                       description: Status for this version of this component
                       type: string
                       enum:
-                        - Active
                         - Deprecated
                         - Forbidden
+                        - Outdated
+                        - Unscored
+                        - Up-to-date
                     icon_class:
                       description: Optional Font Awesome icon class
                       type: string
-                      nullable: true
-                    score:
-                      description: |
-                        Score for this component
-
-                        If this property is `null`, then this component is not included
-                        in the total project score calculation.
-                      type: integer
-                      minimum: 0
-                      maximum: 100
                       nullable: true
                     link:
                       description: Link to the component
@@ -63,14 +55,12 @@ paths:
                     - version
                     - status
                     - icon_class
-                    - score
                   example:
                     package_url: "pkg:pypi:imbi"
                     name: "Imbi"
                     version: "0.21.1"
-                    status: "Active"
+                    status: "Up-to-date"
                     icon_class: "imbi imbi"
-                    score: 100
             application/msgpack:
               <<: *projectComponentsRsp
           headers:


### PR DESCRIPTION
I pivoted away from a per-component numeric score to a status based on the component's active version and the project's version of the component.

Corresponds to specification in https://github.com/AWeber-Imbi/imbi-api/pull/107