### PR TITLE
Add active_version to /projects/{id}/components

### DIFF
--- a/src/endpoints/project_components.yaml
+++ b/src/endpoints/project_components.yaml
@@ -32,6 +32,10 @@ paths:
                     version:
                       description: Version number that the project requires
                       type: string
+                    active_version:
+                      description: Optional "active" version specification
+                      type: string
+                      nullable: true
                     status:
                       description: Status for this version of this component
                       type: string


### PR DESCRIPTION
The API was returning this *instead of* version 🙁 