### PR TITLE
Permit comma-separation in Ops Log ticket slugs

### DIFF
--- a/src/schemas/operations_log.yaml
+++ b/src/schemas/operations_log.yaml
@@ -67,7 +67,7 @@ read:
     ticket_slug:
       description: An optional slug of the ticket that the change was made for
       type: string
-      pattern: ^[\w-]+$
+      pattern: "^[-,\\w]+$"
       nullable: true
     version:
       description: An optional version that the change was made for
@@ -126,7 +126,7 @@ write:
     ticket_slug:
       description: An optional slug of the ticket that the change was made for
       type: string
-      pattern: ^[\w-]+$
+      pattern: "^[-,\\w]+$"
       nullable: true
     version:
       description: An optional version that the change was made for

--- a/src/schemas/operations_log.yaml
+++ b/src/schemas/operations_log.yaml
@@ -133,6 +133,7 @@ write:
       type: string
       nullable: true
   required:
+    - recorded_at
     - recorded_by
     - environment
     - change_type


### PR DESCRIPTION
This doesn't change the backend storage; however, the UI will be updated to allow for commas (and spaces) during editing with the spaces being removed before saving.

I also added `recorded_at` to the list of required properties since the API fails without it (https://github.com/AWeber-Imbi/imbi/issues/91).