### PR TITLE
Add Operations Log occurred_at

### DIFF
--- a/src/schemas/operations_log.yaml
+++ b/src/schemas/operations_log.yaml
@@ -6,8 +6,12 @@ read:
     id:
       description: Surrogate ID for deleting and modifying entries
       type: number
+    occurred_at:
+      description: Timestamp indicating when the event occurred
+      type: string
+      format: iso8601-timestamp
     recorded_at:
-      description: Timestamp indicating when the change was made
+      description: Timestamp indicating when the event was recorded
       type: string
       format: iso8601-timestamp
     recorded_by:
@@ -80,13 +84,11 @@ write:
   description: Describes an audit log entry for entity operational changes
   type: object
   properties:
-    recorded_at:
-      description: Timestamp indicating when the change was made
+    occurred_at:
+      description: Timestamp indicating when the event occurred
       type: string
       format: iso8601-timestamp
-    recorded_by:
-      description: The user who recorded the change
-      type: string
+      nullable: true
     completed_at:
       description: If specified, indicates the change occurred over a span of time
       type: string
@@ -133,8 +135,6 @@ write:
       type: string
       nullable: true
   required:
-    - recorded_at
-    - recorded_by
     - environment
     - change_type
     - description


### PR DESCRIPTION
This field tracks *when* the event occurred at as opposed to when it was added to the system. The recorded at field tracks when it was added.

I also removed the ability to set recorded_at and recorded_by since they are set automatically by the API. We specifically DO NOT want the user to be able to set these.