### PR TITLE
Add OperationsLog.performed_by

### DIFF
--- a/src/endpoints/operations_log.yaml
+++ b/src/endpoints/operations_log.yaml
@@ -94,6 +94,7 @@ paths:
                     - id: 1
                       recorded_at: 2021-05-21T18:39:24.197537
                       recorded_by: gavinr
+                      performed_by: null
                       type: OperationsLogEntry
                       display_name: Gavin M. Roy
                       email_address: gavinr@example.com
@@ -109,6 +110,7 @@ paths:
                     - id: 2
                       recorded_at: 2021-05-21T18:42:00
                       recorded_by: gavinr
+                      performed_by: null
                       type: OperationsLogEntry
                       display_name: Gavin M. Roy
                       email_address: gavinr@example.com
@@ -124,6 +126,7 @@ paths:
                     - id: 3
                       recorded_at: 2021-05-21T19:00:00
                       recorded_by: gavinr
+                      performed_by: null
                       type: OperationsLogEntry
                       display_name: Gavin M. Roy
                       email_address: gavinr@example.com
@@ -238,10 +241,11 @@ components:
         recorded_at: 2021-05-21T18:39:24.197537
         recorded_by: gavinr
         type: OperationsLogEntry
-        display_name: Gavin M. Roy
-        email_address: gavinr@example.com
+        display_name: Dave Shawley
+        email_address: daves@example.com
         completed_at: ~
         project_id: 100
+        performed_by: daves
         environment: Testing
         change_type: Deployment
         description: Added the Operations Log functionality
@@ -252,8 +256,7 @@ components:
     write:
       summary: An operations log entry example
       value:
-        recorded_at: 2021-05-21T18:39:24.197537
-        recorded_by: gavinr
+        performed_by: daves
         completed_at: ~
         project_id: 100
         environment: Testing

--- a/src/schemas/operations_log.yaml
+++ b/src/schemas/operations_log.yaml
@@ -28,6 +28,10 @@ read:
       type: string
       format: iso8601-timestamp
       nullable: true
+    performed_by:
+      description: Identifies the user that performed the action
+      type: string
+      nullable: true
     project_id:
       description: The ID of the project that was changed
       type: number
@@ -94,6 +98,9 @@ write:
       type: string
       format: iso8601-timestamp
       nullable: true
+    performed_by:
+      description: Identifies the user that performed the action
+      type: string
     project_id:
       description: The ID of the project that was changed
       type: number


### PR DESCRIPTION
This is an optional override of `recorded_by` for display purposes. If it is included in the `POST /operations-log` request, then it will be returned from `GET /operations-log/{id}`. Otherwise, `performed_by` will be `null` in the various read operations.