### PR TITLE
Add id params to opensearch index endpoints

### DIFF
--- a/src/endpoints/operations_log.yaml
+++ b/src/endpoints/operations_log.yaml
@@ -208,10 +208,18 @@ paths:
 
   search:
     post:
-      summary: Index the operations log
+      summary: Index operations log entries
       description: |-
-        Queue all operations log entries to be added to the opensearch index
+        Queue operations log entries to be added to the opensearch index. If the `id`
+        query parameter is not given, then all operations log entries are reindexed.
       tags: [Operations Log]
+      parameters:
+        - name: id
+          in: query
+          description: Optional operation entry ID(s) to reindex
+          required: false
+          schema:
+            type: integer
       responses:
         '200':
           description: The request to index the operations log was successful

--- a/src/endpoints/projects.yaml
+++ b/src/endpoints/projects.yaml
@@ -168,10 +168,18 @@ paths:
           type: number
   search:
     post:
-      summary: Index all projects
+      summary: Index projects
       description: |-
-        Queue all projects to be added to the opensearch index
+        Queue projects to be added to the opensearch index. If the `id` query
+        parameter is not given, then all projects are reindexed.
       tags: [Projects]
+      parameters:
+        - name: id
+          in: query
+          description: Optional project ID(s) to reindex
+          required: false
+          schema:
+            type: integer
       responses:
         '200':
           description: The request to index all projects was successful


### PR DESCRIPTION
This PR adds an optional `id` parameter to the `/operations-log/build-search-index` and `/projects/build-search-index` endpoints. If the parameter is not present, then it uses the current behavior. If it is specified, then only the specified ID (or IDs) will be reindexed.