### PR TITLE
Fix spec discrepancies with actual API responses

### DIFF
--- a/src/endpoints/namespace.yaml
+++ b/src/endpoints/namespace.yaml
@@ -62,11 +62,12 @@ paths:
   manage:
     get:
       summary: Get Record
-      description: Retrieve a namespace record
+      description: Retrieve a namespace record. Requires admin permission.
       tags: [Namespaces]
       responses:
         '200': { $ref: '#/components/responses/Success' }
         '401': { $ref: '../components/responses.yaml#/Unauthorized' }
+        '403': { $ref: '../components/responses.yaml#/Forbidden' }
         '404': { $ref: '../components/responses.yaml#/NotFound' }
     patch:
       summary: Update Record
@@ -81,15 +82,17 @@ paths:
         '304': { $ref: '../components/responses.yaml#/NoChanges' }
         '400': { $ref: '../components/responses.yaml#/RequestError' }
         '401': { $ref: '../components/responses.yaml#/Unauthorized' }
+        '403': { $ref: '../components/responses.yaml#/Forbidden' }
         '404': { $ref: '../components/responses.yaml#/NotFound' }
         '409': { $ref: '../components/responses.yaml#/Conflict' }
     delete:
       summary: Delete Record
-      description: Remove a namespace record
+      description: Remove a namespace record. Requires admin permission.
       tags: [Namespaces]
       responses:
         '204': { $ref: '../components/responses.yaml#/RecordRemoved' }
         '401': { $ref: '../components/responses.yaml#/Unauthorized' }
+        '403': { $ref: '../components/responses.yaml#/Forbidden' }
         '404': { $ref: '../components/responses.yaml#/NotFound' }
     parameters:
       - name: id

--- a/src/endpoints/namespace.yaml
+++ b/src/endpoints/namespace.yaml
@@ -137,7 +137,7 @@ components:
       content:
         application/json: &responsesSuccess
           schema:
-            $ref: '../schemas/namespace.yaml#/read'
+            $ref: '../schemas/namespace.yaml#/record'
           examples:
             record:
               $ref: '#/components/examples/read'

--- a/src/endpoints/project_fact_type.yaml
+++ b/src/endpoints/project_fact_type.yaml
@@ -166,7 +166,7 @@ components:
       content:
         application/json: &componentResponsesSuccess
           schema:
-            $ref: '../schemas/project_fact_type.yaml#/read'
+            $ref: '../schemas/project_fact_type.yaml#/record'
           examples:
             record:
               $ref: '#/components/examples/read'

--- a/src/endpoints/project_fact_type.yaml
+++ b/src/endpoints/project_fact_type.yaml
@@ -93,11 +93,12 @@ paths:
   manage:
     get:
       summary: Get Record
-      description: Retrieve a project fact type record
+      description: Retrieve a project fact type record. Requires admin permission.
       tags: [Fact Types]
       responses:
         '200': { $ref: '#/components/responses/Success' }
         '401': { $ref: '../components/responses.yaml#/Unauthorized' }
+        '403': { $ref: '../components/responses.yaml#/Forbidden' }
         '404': { $ref: '../components/responses.yaml#/NotFound' }
     patch:
       summary: Update Record
@@ -112,15 +113,17 @@ paths:
         '304': { $ref: '../components/responses.yaml#/NoChanges' }
         '400': { $ref: '../components/responses.yaml#/RequestError' }
         '401': { $ref: '../components/responses.yaml#/Unauthorized' }
+        '403': { $ref: '../components/responses.yaml#/Forbidden' }
         '404': { $ref: '../components/responses.yaml#/NotFound' }
         '409': { $ref: '../components/responses.yaml#/Conflict' }
     delete:
       summary: Delete Record
-      description: Remove a project fact type record
+      description: Remove a project fact type record. Requires admin permission.
       tags: [Fact Types]
       responses:
         '204': { $ref: '../components/responses.yaml#/RecordRemoved' }
         '401': { $ref: '../components/responses.yaml#/Unauthorized' }
+        '403': { $ref: '../components/responses.yaml#/Forbidden' }
         '404': { $ref: '../components/responses.yaml#/NotFound' }
     parameters:
       - name: fact_type_id

--- a/src/endpoints/project_fact_type_enum.yaml
+++ b/src/endpoints/project_fact_type_enum.yaml
@@ -138,7 +138,7 @@ components:
       content:
         application/json: &responsesSuccess
           schema:
-            $ref: '../schemas/project_fact_type_enum.yaml#/read'
+            $ref: '../schemas/project_fact_type_enum.yaml#/record'
           examples:
             record:
               $ref: '#/components/examples/read'

--- a/src/endpoints/project_fact_type_range.yaml
+++ b/src/endpoints/project_fact_type_range.yaml
@@ -133,7 +133,7 @@ components:
       content:
         application/json: &responsesSuccess
           schema:
-            $ref: '../schemas/project_fact_type_range.yaml#/read'
+            $ref: '../schemas/project_fact_type_range.yaml#/record'
           examples:
             record:
               $ref: '#/components/examples/read'

--- a/src/endpoints/project_facts.yaml
+++ b/src/endpoints/project_facts.yaml
@@ -55,14 +55,14 @@ components:
       summary: All the current facts for a project
       value:
         - fact_type_id: 1
-          fact_name: Programming Language
+          name: Programming Language
           recorded_at: 2021-03-01T12:00:00Z
           recorded_by: test_user
           value: Python 3.9
           score: 100
           weight: 25
         - fact_type_id: 2
-          fact_name: Test Coverage
+          name: Test Coverage
           recorded_at: 2021-03-01T12:00:01Z
           recorded_by: test_user
           value: 95.6

--- a/src/endpoints/project_type.yaml
+++ b/src/endpoints/project_type.yaml
@@ -56,11 +56,12 @@ paths:
   manage:
     get:
       summary: Get Record
-      description: Retrieve a project type record
+      description: Retrieve a project type record. Requires admin permission.
       tags: [Project Types]
       responses:
         '200': { $ref: '#/components/responses/Success' }
         '401': { $ref: '../components/responses.yaml#/Unauthorized' }
+        '403': { $ref: '../components/responses.yaml#/Forbidden' }
         '404': { $ref: '../components/responses.yaml#/NotFound' }
     patch:
       summary: Update Record
@@ -75,15 +76,17 @@ paths:
         '304': { $ref: '../components/responses.yaml#/NoChanges' }
         '400': { $ref: '../components/responses.yaml#/RequestError' }
         '401': { $ref: '../components/responses.yaml#/Unauthorized' }
+        '403': { $ref: '../components/responses.yaml#/Forbidden' }
         '404': { $ref: '../components/responses.yaml#/NotFound' }
         '409': { $ref: '../components/responses.yaml#/Conflict' }
     delete:
       summary: Delete Record
-      description: Remove a project type record
+      description: Remove a project type record. Requires admin permission.
       tags: [Project Types]
       responses:
         '204': { $ref: '../components/responses.yaml#/RecordRemoved' }
         '401': { $ref: '../components/responses.yaml#/Unauthorized' }
+        '403': { $ref: '../components/responses.yaml#/Forbidden' }
         '404': { $ref: '../components/responses.yaml#/NotFound' }
     parameters:
       - name: id

--- a/src/endpoints/project_type.yaml
+++ b/src/endpoints/project_type.yaml
@@ -125,7 +125,7 @@ components:
       content:
         application/json: &responsesSuccess
           schema:
-            $ref: '../schemas/project_type.yaml#/read'
+            $ref: '../schemas/project_type.yaml#/record'
           examples:
             record:
               $ref: '#/components/examples/read'

--- a/src/endpoints/projects.yaml
+++ b/src/endpoints/projects.yaml
@@ -12,7 +12,7 @@ paths:
             type: integer
         - name: project_type_id
           in: query
-          description: Filter by Namespace ID
+          description: Filter by Project Type ID
           schema:
             type: integer
         - name: name

--- a/src/schemas/namespace.yaml
+++ b/src/schemas/namespace.yaml
@@ -1,6 +1,55 @@
 read:
   title: Namespace
-  description: Used to create namespaces for project organization
+  description: |
+    Used to create namespaces for project organization.
+    This schema is used for collection responses.
+  type: object
+  properties:
+    id:
+      description: The surrogate key for URLs and table linking
+      type: number
+    name:
+      description: The namespace name
+      type: string
+    slug:
+      description: Team path slug / abbreviation
+      type: string
+    icon_class:
+      description: Font Awesome UI icon class
+      type: string
+    maintained_by:
+      description: Association of the namespace to one or more internal or external Imbi groups
+      type: array
+      items:
+        type: string
+      nullable: true
+    gitlab_group_name:
+      description: Optional name of associated GitLab group
+      type: string
+      nullable: true
+    sentry_team_slug:
+      description: Optional name of associated Sentry team
+      type: string
+      nullable: true
+    pagerduty_policy:
+      description: Optional ID of associated PagerDuty escalation policy
+      type: string
+      nullable: true
+    aws_ssm_slug:
+      description: Optional slug of the namespace in the AWS SSM path
+      type: string
+      nullable: true
+  required:
+    - name
+    - slug
+    - icon_class
+  additionalProperties: false
+
+record:
+  title: Namespace Record
+  description: |
+    Used to create namespaces for project organization.
+    This schema is used for single record responses and includes audit fields.
   type: object
   properties:
     id:

--- a/src/schemas/project.yaml
+++ b/src/schemas/project.yaml
@@ -12,17 +12,35 @@ read:
     last_modified_by:
       description: The user that last modified the record
       type: string
+    created_at:
+      description: When the project was created
+      type: string
+      format: iso8601-timestamp
+    last_modified_at:
+      description: When the project was last modified
+      type: string
+      format: iso8601-timestamp
+      nullable: true
     namespace_id:
       description: The project namespace ID
       type: number
     namespace:
       description: The namespace name
       type: string
+    namespace_slug:
+      description: URL slug for the namespace
+      type: string
+    namespace_icon:
+      description: Font Awesome icon class for the namespace
+      type: string
     project_type_id:
       description: The project type ID
       type: number
     project_type:
       description: The project type name
+      type: string
+    project_icon:
+      description: Font Awesome icon class for the project type
       type: string
     name:
       description: The project name
@@ -44,6 +62,10 @@ read:
     archived:
       description: Indicates that the project is archived
       type: boolean
+    project_score:
+      description: Calculated project health score
+      type: number
+      nullable: true
     gitlab_project_id:
       description: Optional project ID for the associated gitlab project
       type: integer

--- a/src/schemas/project_fact.yaml
+++ b/src/schemas/project_fact.yaml
@@ -6,7 +6,7 @@ read:
     fact_type_id:
       description: The ID of the fact type that is being set
       type: integer
-    fact_name:
+    name:
       type: string
     recorded_at:
       description: When the fact was recorded
@@ -29,6 +29,17 @@ read:
     weight:
       description: The weight of the score against all the other project facts
       type: integer
+    ui_options:
+      description: An array of values that are used in the UI for display purposes
+      type: array
+      items:
+        type: string
+        enum:
+          - display-as-badge
+          - display-as-percentage
+          - hidden
+          - read-only
+      uniqueItems: true
   additionalProperties: false
 
 write:

--- a/src/schemas/project_fact_type.yaml
+++ b/src/schemas/project_fact_type.yaml
@@ -1,7 +1,65 @@
 read:
   title: Project Fact Type
   description: |
-    Defines types of facts that can be recorded about a project
+    Defines types of facts that can be recorded about a project.
+    This schema is used for collection responses.
+  type: object
+  properties:
+    id:
+      description: The surrogate ID
+      type: number
+    name:
+      description: The project fact type name
+      type: string
+    project_type_ids:
+      description: An array of Project Type ids to associate the fact type with
+      type: array
+      items:
+        type: number
+      uniqueItems: true
+    fact_type:
+      description: Indicates how a fact value is validated and scored
+      type: string
+      enum:
+        - enum
+        - free-form
+        - range
+    description:
+      description: Provides additional context about the fact typee
+      type: string
+      nullable: true
+    data_type:
+      description: The data type for the value
+      type: string
+      enum:
+        - boolean
+        - date
+        - decimal
+        - integer
+        - string
+        - timestamp
+    ui_options:
+      description: An array of values that are used in the UI for display purposes
+      type: array
+      items:
+        type: string
+        enum:
+          - display-as-badge
+          - display-as-percentage
+          - hidden
+          - read-only
+      uniqueItems: true
+    weight:
+      description: The weight of the fact type when computing a project score
+      type: number
+      default: 0
+  additionalProperties: false
+
+record:
+  title: Project Fact Type Record
+  description: |
+    Defines types of facts that can be recorded about a project.
+    This schema is used for single record responses and includes audit fields.
   type: object
   properties:
     id:

--- a/src/schemas/project_fact_type.yaml
+++ b/src/schemas/project_fact_type.yaml
@@ -25,7 +25,7 @@ read:
         - free-form
         - range
     description:
-      description: Provides additional context about the fact typee
+      description: Provides additional context about the fact type
       type: string
       nullable: true
     data_type:
@@ -88,7 +88,7 @@ record:
         - free-form
         - range
     description:
-      description: Provides additional context about the fact typee
+      description: Provides additional context about the fact type
       type: string
       nullable: true
     data_type:
@@ -141,7 +141,7 @@ write:
         - free-form
         - range
     description:
-      description: Provides additional context about the fact typee
+      description: Provides additional context about the fact type
       type: string
       nullable: true
     data_type:

--- a/src/schemas/project_fact_type_enum.yaml
+++ b/src/schemas/project_fact_type_enum.yaml
@@ -1,7 +1,33 @@
 read:
   title: Project Fact Type Enum Value
   description: |
-    Defines options that are available for an enum project fact type
+    Defines options that are available for an enum project fact type.
+    This schema is used for collection responses.
+  type: object
+  properties:
+    id:
+      description: The surrogate key for the fact type option
+      type: number
+    fact_type_id:
+      description: The ID of the fact type the option is for
+      type: string
+    value:
+      description: The option value
+      type: string
+    icon_class:
+      description: An icon that is specific to the fact type option
+      type: string
+    score:
+      description: The score value for the option
+      type: number
+      default: 0
+  additionalProperties: false
+
+record:
+  title: Project Fact Type Enum Value Record
+  description: |
+    Defines options that are available for an enum project fact type.
+    This schema is used for single record responses and includes audit fields.
   type: object
   properties:
     id:

--- a/src/schemas/project_fact_type_range.yaml
+++ b/src/schemas/project_fact_type_range.yaml
@@ -1,7 +1,33 @@
 read:
   title: Project Fact Type Range Value
   description: |
-    Defines options that are available for an range project fact type
+    Defines options that are available for an range project fact type.
+    This schema is used for collection responses.
+  type: object
+  properties:
+    id:
+      description: The surrogate key for the fact type option
+      type: number
+    fact_type_id:
+      description: The ID of the fact type the option is for
+      type: string
+    min_value:
+      description: The min value for the range
+      type: number
+    max_value:
+      description: The max value for the range
+      type: number
+    score:
+      description: The score value for the option
+      type: number
+      default: 0
+  additionalProperties: false
+
+record:
+  title: Project Fact Type Range Value Record
+  description: |
+    Defines options that are available for an range project fact type.
+    This schema is used for single record responses and includes audit fields.
   type: object
   properties:
     id:

--- a/src/schemas/project_type.yaml
+++ b/src/schemas/project_type.yaml
@@ -1,7 +1,51 @@
 read:
   title: Project Type
   description: |
-    Used to describe the types of operational project_types for projects
+    Used to describe the types of operational project_types for projects.
+    This schema is used for collection responses.
+  type: object
+  properties:
+    id:
+      description: The surrogate key for URLs and table linking
+      type: number
+    name:
+      description: The display name for a project type
+      type: string
+    plural_name:
+      description: The display name for a project type when there is more than 1 item
+      type: string
+    description:
+      description: A description of the project type
+      type: string
+      nullable: true
+    slug:
+      description: The slug for project types, used in filtering
+      type: string
+    icon_class:
+      description: Font Awesome UI icon class
+      type: string
+    environment_urls:
+      description: Indicates that projects of this type have per-environment URLs
+      type: boolean
+    gitlab_project_prefix:
+      description: Prefix for this project type in GitLab
+      type: string
+      nullable: true
+    github_org:
+      description: GitHub organization to use when creating repositories, overrides project type slug if set
+      type: string
+      nullable: true
+    ssm_path_override:
+      description: Override the slug of this type when generating SSM paths
+      type: string
+      nullable: true
+  additionalProperties: false
+
+record:
+  title: Project Type Record
+  description: |
+    Used to describe the types of operational project_types for projects.
+    This schema is used for single record responses and includes audit fields.
   type: object
   properties:
     id:


### PR DESCRIPTION
## Summary

Fixes multiple discrepancies between the OpenAPI spec and actual API responses, verified against a live Imbi instance.

### Changes

1. **Rename `fact_name` to `name` in project facts** - API returns `name`, spec incorrectly documented `fact_name`

2. **Add missing fields to `/projects` response** - Added 6 fields returned by API but not documented:
   - `created_at`, `last_modified_at` (timestamps)
   - `namespace_slug`, `namespace_icon` (namespace display fields)
   - `project_icon`, `project_score` (project display fields)

3. **Add `ui_options` to project facts schema** - Field returned by API but missing from spec

4. **Split read/record schemas for admin endpoints** - Collection vs single-record responses return different fields:
   - `/project-types`, `/namespaces`, `/project-fact-types` (and enum/range sub-endpoints)
   - Collection responses exclude `created_by`/`last_modified_by`
   - Single record responses include audit fields

5. **Fix `project_type_id` parameter description typo** - Was incorrectly "Filter by Namespace ID"

6. **Add 403 Forbidden responses for admin-required endpoints** - Single-record endpoints require admin permission; now documented with 403 response

### Endpoints Affected

| Endpoint | Changes |
|----------|---------|
| `GET /projects` | Added 6 missing fields, fixed param typo |
| `GET /projects/{id}/facts` | `fact_name` → `name`, added `ui_options` |
| `/project-types` | Schema split (read/record), 403 responses |
| `/namespaces` | Schema split (read/record), 403 responses |
| `/project-fact-types` | Schema split (read/record), 403 responses |
| `/project-fact-types/{id}/enums` | Schema split (read/record) |
| `/project-fact-types/{id}/ranges` | Schema split (read/record) |

### Verification

- Tested against a live Imbi API instance
- Collection endpoints verified to exclude audit fields
- Single-record endpoints confirmed to require admin permission (403)

### Note: Potential Design Question

While documenting, we noticed that single-record GET endpoints (e.g., `GET /project-types/{id}`) require admin permission, but the only additional data they return over collection endpoints is audit metadata (`created_by`, `last_modified_by`, timestamps). This may be intentional, but could be worth reviewing whether admin permission is necessary just for audit field visibility.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Expanded responses with timestamps, audit fields, icons, scores and UI options; collection and single-record formats clarified.
* **Bug Fixes**
  * Fixed project_type_id query description and renamed example field for project facts; added missing example values.
* **Security**
  * Manage endpoints now return 403 Forbidden when admin permissions are required.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>
<!-- end of auto-generated comment: release notes by coderabbit.ai -->